### PR TITLE
upgrade bdc-db dependency to 0.4.3 (close #99)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ Changes
 =======
 
 
+Version 0.4.1 (2021-03-17)
+--------------------------
+
+- Upgrade BDC-DB dependency to 0.4.3 to keep SQLAlchemy in version 1.3 until SQLAlchemyUtils is updated for SQLAlchemy 1.4. (`#99 <https://github.com/brazil-data-cube/lccs-db/issues/99>`_).
+
+
 Version 0.4.0 (2020-12-09)
 --------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'bdc-db @ git+git://github.com/brazil-data-cube/bdc-db@v0.4.2'
+    'bdc-db @ git+git://github.com/brazil-data-cube/bdc-db@v0.4.3'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
It solves temporally the error related with sqlalchemy-utils support with sqlalchemy 1.4